### PR TITLE
fix(mail): correctness fixes for queued mailer + result classification

### DIFF
--- a/src/main/kotlin/com/vandeas/service/RateLimitedMailQueue.kt
+++ b/src/main/kotlin/com/vandeas/service/RateLimitedMailQueue.kt
@@ -219,8 +219,8 @@ class RateLimitedMailQueue(
                 }
 
                 result.temporary.isNotEmpty() && item.retryCount < item.maxRetries -> {
-                    // Re-queue for retry with exponential backoff
-                    val retryDelay = (1000L * (item.retryCount + 1)).milliseconds
+                    // Re-queue for retry with exponential backoff: 1s, 2s, 4s, 8s, ...
+                    val retryDelay = (1000L shl item.retryCount).milliseconds
                     logger.warn("Temporary failure for ${item.mail.to}, retrying in $retryDelay (attempt ${item.retryCount + 1}/${item.maxRetries})")
 
                     // Emit intermediate result to notify consumers about the retry attempt

--- a/src/main/kotlin/com/vandeas/service/RateLimitedMailQueue.kt
+++ b/src/main/kotlin/com/vandeas/service/RateLimitedMailQueue.kt
@@ -257,6 +257,9 @@ class RateLimitedMailQueue(
                     _results.emit(QueuedMailResult(item.reference, result))
                 }
             }
+        } catch (e: CancellationException) {
+            // Structured concurrency: cancellation must propagate, not be reported as a failure.
+            throw e
         } catch (e: Exception) {
             logger.error("Error processing mail item ${item.reference}: ${e.message}", e)
             _results.emit(

--- a/src/main/kotlin/com/vandeas/service/RateLimitedMailQueue.kt
+++ b/src/main/kotlin/com/vandeas/service/RateLimitedMailQueue.kt
@@ -256,6 +256,23 @@ class RateLimitedMailQueue(
                     logger.error("Failed to send mail to ${item.mail.to} (ref: ${item.reference})")
                     _results.emit(QueuedMailResult(item.reference, result))
                 }
+
+                result.temporary.isNotEmpty() -> {
+                    // Retries exhausted: promote to a terminal failure rather than dropping silently.
+                    logger.error("Retries exhausted for ${item.mail.to} (ref: ${item.reference}) after ${item.retryCount} attempt(s)")
+                    _results.emit(
+                        QueuedMailResult(
+                            item.reference,
+                            SendOperationResult(failed = listOf(item.mail.to))
+                        )
+                    )
+                }
+
+                else -> {
+                    // Empty/unrecognised result. Surface it instead of dropping it on the floor.
+                    logger.warn("Mailer returned an empty result for ${item.mail.to} (ref: ${item.reference}); emitting as-is")
+                    _results.emit(QueuedMailResult(item.reference, result))
+                }
             }
         } catch (e: CancellationException) {
             // Structured concurrency: cancellation must propagate, not be reported as a failure.

--- a/src/main/kotlin/com/vandeas/service/RateLimitedMailQueue.kt
+++ b/src/main/kotlin/com/vandeas/service/RateLimitedMailQueue.kt
@@ -67,6 +67,14 @@ class RateLimitedMailQueue(
      */
     suspend fun enqueue(item: MailQueueItem): String {
         queuedCount.incrementAndGet()
+        return submit(item)
+    }
+
+    /**
+     * Internal re-enqueue used by the retry path. Skips [queuedCount] so stats
+     * reflect caller-initiated enqueues only.
+     */
+    private suspend fun submit(item: MailQueueItem): String {
         queue.send(item)
         logger.debug("Enqueued mail with reference: ${item.reference} (priority: ${item.priority})")
         return item.reference
@@ -231,7 +239,7 @@ class RateLimitedMailQueue(
                         try {
                             delay(retryDelay)
                             val retryItem = item.copy(retryCount = item.retryCount + 1)
-                            enqueue(retryItem)
+                            submit(retryItem)
                         } catch (e: CancellationException) {
                             logger.info("Retry cancelled for ${item.mail.to} (ref: ${item.reference})")
                             throw e

--- a/src/main/kotlin/com/vandeas/service/impl/mailer/ResendMailer.kt
+++ b/src/main/kotlin/com/vandeas/service/impl/mailer/ResendMailer.kt
@@ -49,60 +49,11 @@ class ResendMailer(
         } catch (e: ResendException) {
             logger.error("Failed to send email to $to")
             logger.error("Error: ${e.message}")
-
-            val statusCode = e.statusCode
-            logger.debug("HTTP Status Code: $statusCode")
-
-            return when (statusCode) {
-                // 4xx errors (except rate limit) are typically permanent failures
-                400, 404 -> {
-                    // Bad request or email not found - permanent failure
-                    logger.warn("Email bounced (permanent failure): $to - Status: $statusCode")
-                    SendOperationResult(
-                        bounced = listOf(to),
-                        failed = listOf(to)
-                    )
-                }
-                422 -> {
-                    // Unprocessable entity - usually validation errors (permanent)
-                    logger.warn("Email bounced (validation error): $to - Status: $statusCode")
-                    SendOperationResult(
-                        bounced = listOf(to),
-                        failed = listOf(to)
-                    )
-                }
-                429 -> {
-                    // Rate limit - temporary failure, should retry later
-                    logger.warn("Rate limit hit, temporary failure: $to - Status: $statusCode")
-                    SendOperationResult(
-                        temporary = listOf(to),
-                        failed = listOf(to)
-                    )
-                }
-                in 500..599 -> {
-                    // Server errors - temporary failures, should retry
-                    logger.warn("Server error, temporary failure: $to - Status: $statusCode")
-                    SendOperationResult(
-                        temporary = listOf(to),
-                        failed = listOf(to)
-                    )
-                }
-                else -> {
-                    // Unknown status codes - treat as temporary to allow retry
-                    logger.warn("Unknown failure type (status: $statusCode), treating as temporary: $to")
-                    SendOperationResult(
-                        temporary = listOf(to),
-                        failed = listOf(to)
-                    )
-                }
-            }
+            logger.debug("HTTP Status Code: ${e.statusCode}")
+            classifyResendStatus(to, e.statusCode)
         } catch (e: Exception) {
-            // Catch-all for unexpected errors (network issues, timeouts, etc.)
             logger.error("Unexpected error while sending email to $to: ${e.message}")
-            SendOperationResult(
-                temporary = listOf(to),
-                failed = listOf(to)
-            )
+            classifyUnexpectedException(to, e)
         }
     }
 
@@ -154,5 +105,24 @@ class ResendMailer(
                 temporary = results.flatMap { it.temporary }
             )
         }
+    }
+
+    companion object {
+        /**
+         * Classify a Resend HTTP status code into a result for [to].
+         *
+         * The address is placed into exactly one of `bounced` or `temporary` — never also
+         * into `failed`, which is reserved for the queue's terminal failure decision.
+         */
+        fun classifyResendStatus(to: String, statusCode: Int): SendOperationResult = when (statusCode) {
+            400, 404, 422 -> SendOperationResult(bounced = listOf(to))
+            429 -> SendOperationResult(temporary = listOf(to))
+            in 500..599 -> SendOperationResult(temporary = listOf(to))
+            else -> SendOperationResult(temporary = listOf(to))
+        }
+
+        /** Network/timeout/etc.: retry. */
+        fun classifyUnexpectedException(to: String, @Suppress("UNUSED_PARAMETER") e: Exception): SendOperationResult =
+            SendOperationResult(temporary = listOf(to))
     }
 }

--- a/src/main/kotlin/com/vandeas/service/impl/mailer/SMTPMailer.kt
+++ b/src/main/kotlin/com/vandeas/service/impl/mailer/SMTPMailer.kt
@@ -76,51 +76,13 @@ class SMTPMailer(
 		} catch (e: SendFailedException) {
             LOGGER.error("Failed to send email to $to")
             LOGGER.error("Error: ${e.message}")
-
-            // Check for permanent failures
-            // invalidAddresses: addresses that failed validation (permanent)
-            // SMTP 5xx codes (except 421): permanent failures
-            val hasInvalidAddresses = e.invalidAddresses?.isNotEmpty() == true
-            val isPermanentSMTPError = e.message?.let { msg ->
-                msg.contains("550", ignoreCase = true) ||  // Mailbox not found
-                msg.contains("551", ignoreCase = true) ||  // User not local
-                msg.contains("552", ignoreCase = true) ||  // Mailbox full
-                msg.contains("553", ignoreCase = true) ||  // Invalid address
-                msg.contains("554", ignoreCase = true)     // Transaction failed
-            } ?: false
-
-            val isPermanentFailure = hasInvalidAddresses || isPermanentSMTPError
-
-            if (isPermanentFailure) {
-                LOGGER.warn("Email bounced (permanent failure): $to - Invalid addresses: ${e.invalidAddresses?.size ?: 0}")
-                SendOperationResult(
-                    bounced = listOf(to),
-                    failed = listOf(to)
-                )
-            } else {
-                // Temporary failures: validUnsentAddresses (validated but not sent), 4xx codes, etc.
-                LOGGER.warn("Temporary email failure: $to - Valid unsent: ${e.validUnsentAddresses?.size ?: 0}")
-                SendOperationResult(
-                    temporary = listOf(to),
-                    failed = listOf(to)
-                )
-            }
+            classifySendFailedException(to, e)
 		} catch (e: MessagingException) {
             LOGGER.error("Messaging exception while sending email to $to: ${e.message}")
-
-            // Most messaging exceptions are temporary (network issues, etc.)
-            SendOperationResult(
-                temporary = listOf(to),
-                failed = listOf(to)
-            )
+            classifyMessagingException(to, e)
 		} catch (e: Exception) {
             LOGGER.error("Unexpected error while sending email to $to: ${e.message}")
-
-            // Unknown errors treated as temporary to allow retry
-            SendOperationResult(
-                temporary = listOf(to),
-                failed = listOf(to)
-            )
+            classifyUnexpectedException(to, e)
 		}
 	}
 
@@ -134,4 +96,38 @@ class SMTPMailer(
             temporary = responses.flatMap { it.temporary }
         )
 	}
+
+    companion object {
+        /**
+         * Classify a [SendFailedException] into a result. SMTP 5xx (except 421) and
+         * invalid-address rejections are permanent (bounced); everything else is temporary.
+         *
+         * The address is placed into exactly one of `bounced` or `temporary` — never also
+         * into `failed`, which is reserved for the queue's terminal failure decision.
+         */
+        fun classifySendFailedException(to: String, e: SendFailedException): SendOperationResult {
+            val hasInvalidAddresses = e.invalidAddresses?.isNotEmpty() == true
+            val isPermanentSMTPError = e.message?.let { msg ->
+                msg.contains("550", ignoreCase = true) ||  // Mailbox not found
+                msg.contains("551", ignoreCase = true) ||  // User not local
+                msg.contains("552", ignoreCase = true) ||  // Mailbox full
+                msg.contains("553", ignoreCase = true) ||  // Invalid address
+                msg.contains("554", ignoreCase = true)     // Transaction failed
+            } ?: false
+
+            return if (hasInvalidAddresses || isPermanentSMTPError) {
+                SendOperationResult(bounced = listOf(to))
+            } else {
+                SendOperationResult(temporary = listOf(to))
+            }
+        }
+
+        /** Generic [MessagingException] (network glitch, etc.) is treated as temporary. */
+        fun classifyMessagingException(to: String, @Suppress("UNUSED_PARAMETER") e: MessagingException): SendOperationResult =
+            SendOperationResult(temporary = listOf(to))
+
+        /** Unknown error: treat as temporary so the queue can retry. */
+        fun classifyUnexpectedException(to: String, @Suppress("UNUSED_PARAMETER") e: Exception): SendOperationResult =
+            SendOperationResult(temporary = listOf(to))
+    }
 }

--- a/src/test/kotlin/com/vandeas/service/RateLimitedMailQueueTest.kt
+++ b/src/test/kotlin/com/vandeas/service/RateLimitedMailQueueTest.kt
@@ -258,6 +258,65 @@ class RateLimitedMailQueueTest {
     }
 
     @Test
+    fun `cancellation in mailer should not be reported as a phantom failure`() = runBlocking {
+        // Given: a mailer that throws CancellationException (simulating cooperative cancellation
+        // from the underlying transport, e.g. an HTTP client cancelled mid-request).
+        // The queue's outer catch must rethrow CancellationException rather than emitting a
+        // bogus "failed" result with reason swallowed.
+        val cancellingMailer = object : Mailer {
+            override suspend fun sendEmail(
+                to: String,
+                from: String,
+                subject: String,
+                content: String,
+                attachments: List<Attachment>
+            ): SendOperationResult {
+                throw CancellationException("simulated cancellation")
+            }
+
+            override suspend fun sendEmails(mails: List<Mail>): SendOperationResult =
+                SendOperationResult()
+        }
+
+        val isolatedScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        val isolatedQueue = RateLimitedMailQueue(
+            cancellingMailer,
+            rateLimit = 1000,
+            workerCount = 1,
+            scope = isolatedScope
+        )
+
+        try {
+            val collected = java.util.Collections.synchronizedList(mutableListOf<QueuedMailResult>())
+            val collector = scope.launch { isolatedQueue.results.collect { collected.add(it) } }
+
+            // Let the collector subscribe before enqueueing
+            delay(100.milliseconds)
+
+            isolatedQueue.enqueue(
+                MailQueueItem(
+                    reference = "phantom-ref",
+                    mail = Mail("s@test.com", "to@test.com", "S", "C")
+                )
+            )
+
+            // Give the worker time to pick up and "fail" via cancellation
+            delay(500.milliseconds)
+
+            val phantomEmissions = collected.filter { it.reference == "phantom-ref" }
+            assertTrue(
+                phantomEmissions.isEmpty(),
+                "CancellationException must not be swallowed and reported as a phantom failure; got: $phantomEmissions"
+            )
+
+            collector.cancel()
+        } finally {
+            isolatedQueue.shutdown()
+            isolatedScope.cancel()
+        }
+    }
+
+    @Test
     fun `enqueueAll should add all items to queue`() = runBlocking {
         // Given: Queue with worker pool
         queue = RateLimitedMailQueue(mockMailer, rateLimit = 100, workerCount = 3, scope = scope)

--- a/src/test/kotlin/com/vandeas/service/RateLimitedMailQueueTest.kt
+++ b/src/test/kotlin/com/vandeas/service/RateLimitedMailQueueTest.kt
@@ -258,6 +258,68 @@ class RateLimitedMailQueueTest {
     }
 
     @Test
+    fun `retry backoff should grow exponentially across retries`() = runBlocking {
+        // Given: a mailer that records the wall-clock time of each attempt and always
+        // returns a temporary failure (and only temporary, so we don't hit any other branch).
+        val attemptTimes = java.util.Collections.synchronizedList(mutableListOf<Long>())
+        val timingMailer = object : Mailer {
+            override suspend fun sendEmail(
+                to: String,
+                from: String,
+                subject: String,
+                content: String,
+                attachments: List<Attachment>
+            ): SendOperationResult {
+                attemptTimes.add(System.currentTimeMillis())
+                return SendOperationResult(temporary = listOf(to))
+            }
+
+            override suspend fun sendEmails(mails: List<Mail>): SendOperationResult =
+                SendOperationResult()
+        }
+
+        val isolatedScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        val isolatedQueue = RateLimitedMailQueue(
+            timingMailer,
+            rateLimit = 1000,
+            workerCount = 1,
+            scope = isolatedScope
+        )
+
+        try {
+            isolatedQueue.enqueue(
+                MailQueueItem(
+                    reference = "backoff-ref",
+                    mail = Mail("s@test.com", "backoff@test.com", "S", "C"),
+                    maxRetries = 3
+                )
+            )
+
+            // 4 attempts total: initial + 3 retries.
+            // Linear (1s, 2s, 3s) → ~6s; Exponential (1s, 2s, 4s) → ~7s. We wait up to 12s.
+            withTimeout(12.seconds) {
+                while (attemptTimes.size < 4) delay(50.milliseconds)
+            }
+
+            val deltas = attemptTimes.zipWithNext { a, b -> b - a }
+            // Deltas should be [~1000, ~2000, ~4000] for exponential.
+            // For linear they'd be [~1000, ~2000, ~3000].
+            // The discriminating signal: deltas[2] / deltas[1].
+            //   - linear: ~1.5
+            //   - exponential: ~2.0
+            // Use 1.75 as midpoint cutoff with margin for scheduler jitter.
+            val ratio = deltas[2].toDouble() / deltas[1].toDouble()
+            assertTrue(
+                ratio >= 1.75,
+                "Expected exponential backoff (ratio ≥ 1.75) but got linear-shaped deltas; deltas=$deltas, ratio=$ratio"
+            )
+        } finally {
+            isolatedQueue.shutdown()
+            isolatedScope.cancel()
+        }
+    }
+
+    @Test
     fun `should emit terminal failure when temporary failures exhaust retries`() = runBlocking {
         // Given: A mailer that always returns a temporary failure (and only sets `temporary`,
         // not `failed` — this matches the documented contract).

--- a/src/test/kotlin/com/vandeas/service/RateLimitedMailQueueTest.kt
+++ b/src/test/kotlin/com/vandeas/service/RateLimitedMailQueueTest.kt
@@ -258,6 +258,52 @@ class RateLimitedMailQueueTest {
     }
 
     @Test
+    fun `should emit terminal failure when temporary failures exhaust retries`() = runBlocking {
+        // Given: A mailer that always returns a temporary failure (and only sets `temporary`,
+        // not `failed` — this matches the documented contract).
+        // When retryCount reaches maxRetries, the queue must emit a terminal result with
+        // the address moved into `failed`, not silently drop the item.
+        mockMailer.shouldTemporaryFailFor = setOf("always-temp@test.com")
+        queue = RateLimitedMailQueue(mockMailer, rateLimit = 1000, workerCount = 1, scope = scope)
+
+        val collected = java.util.Collections.synchronizedList(mutableListOf<QueuedMailResult>())
+        val collector = scope.launch { queue.results.collect { collected.add(it) } }
+
+        delay(100.milliseconds)
+
+        queue.enqueue(
+            MailQueueItem(
+                reference = "exhausted-ref",
+                mail = Mail("s@test.com", "always-temp@test.com", "Subject", "Content"),
+                maxRetries = 1
+            )
+        )
+
+        // Wait long enough for: initial attempt + 1 retry (~1s exponential backoff) + processing margin
+        withTimeout(8.seconds) {
+            while (collected.none {
+                    it.reference == "exhausted-ref" &&
+                        it.result.failed.contains("always-temp@test.com") &&
+                        it.result.temporary.isEmpty()
+                }) {
+                delay(50.milliseconds)
+            }
+        }
+
+        collector.cancel()
+
+        val terminal = collected.last { it.reference == "exhausted-ref" }
+        assertTrue(
+            terminal.result.failed.contains("always-temp@test.com"),
+            "Terminal emission must move the address into `failed`; got $terminal"
+        )
+        assertTrue(
+            terminal.result.temporary.isEmpty(),
+            "Terminal emission must clear `temporary`; got $terminal"
+        )
+    }
+
+    @Test
     fun `cancellation in mailer should not be reported as a phantom failure`() = runBlocking {
         // Given: a mailer that throws CancellationException (simulating cooperative cancellation
         // from the underlying transport, e.g. an HTTP client cancelled mid-request).

--- a/src/test/kotlin/com/vandeas/service/RateLimitedMailQueueTest.kt
+++ b/src/test/kotlin/com/vandeas/service/RateLimitedMailQueueTest.kt
@@ -258,6 +258,47 @@ class RateLimitedMailQueueTest {
     }
 
     @Test
+    fun `queuedCount should not double-count retries`() = runBlocking {
+        // Given: a mailer that fails temporarily so the queue retries internally.
+        mockMailer.shouldTemporaryFailFor = setOf("retry@test.com")
+        queue = RateLimitedMailQueue(mockMailer, rateLimit = 1000, workerCount = 1, scope = scope)
+
+        val collected = java.util.Collections.synchronizedList(mutableListOf<QueuedMailResult>())
+        val collector = scope.launch { queue.results.collect { collected.add(it) } }
+
+        delay(100.milliseconds)
+
+        // One enqueue from the caller; queue does its own retries internally.
+        queue.enqueue(
+            MailQueueItem(
+                reference = "retry-ref",
+                mail = Mail("s@test.com", "retry@test.com", "S", "C"),
+                maxRetries = 2
+            )
+        )
+
+        // Wait until the terminal emission lands (so retries have all been attempted).
+        withTimeout(15.seconds) {
+            while (collected.none {
+                    it.reference == "retry-ref" &&
+                        it.result.failed.contains("retry@test.com") &&
+                        it.result.temporary.isEmpty()
+                }) {
+                delay(50.milliseconds)
+            }
+        }
+
+        collector.cancel()
+
+        val stats = queue.getStats()
+        assertEquals(
+            1L,
+            stats.queued,
+            "queued must reflect caller-initiated enqueues, not internal retries; got ${stats.queued}"
+        )
+    }
+
+    @Test
     fun `retry backoff should grow exponentially across retries`() = runBlocking {
         // Given: a mailer that records the wall-clock time of each attempt and always
         // returns a temporary failure (and only temporary, so we don't hit any other branch).

--- a/src/test/kotlin/com/vandeas/service/impl/mailer/ResendMailerClassificationTest.kt
+++ b/src/test/kotlin/com/vandeas/service/impl/mailer/ResendMailerClassificationTest.kt
@@ -1,0 +1,70 @@
+package com.vandeas.service.impl.mailer
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+class ResendMailerClassificationTest {
+
+    private val recipient = "to@example.com"
+
+    @Test
+    fun `400 should classify as bounced only`() {
+        val result = ResendMailer.classifyResendStatus(recipient, statusCode = 400)
+        assertContains(result.bounced, recipient)
+        assertFalse(
+            result.failed.contains(recipient),
+            "Bounced result must not also populate `failed`; got $result"
+        )
+    }
+
+    @Test
+    fun `404 should classify as bounced only`() {
+        val result = ResendMailer.classifyResendStatus(recipient, statusCode = 404)
+        assertContains(result.bounced, recipient)
+        assertFalse(result.failed.contains(recipient))
+    }
+
+    @Test
+    fun `422 should classify as bounced only`() {
+        val result = ResendMailer.classifyResendStatus(recipient, statusCode = 422)
+        assertContains(result.bounced, recipient)
+        assertFalse(result.failed.contains(recipient))
+    }
+
+    @Test
+    fun `429 rate-limit should classify as temporary only`() {
+        val result = ResendMailer.classifyResendStatus(recipient, statusCode = 429)
+        assertContains(result.temporary, recipient)
+        assertFalse(
+            result.failed.contains(recipient),
+            "Temporary result must not also populate `failed`; got $result"
+        )
+    }
+
+    @Test
+    fun `5xx should classify as temporary only`() {
+        listOf(500, 502, 503, 504).forEach { code ->
+            val result = ResendMailer.classifyResendStatus(recipient, statusCode = code)
+            assertContains(result.temporary, recipient, "for code $code")
+            assertFalse(result.failed.contains(recipient), "for code $code; got $result")
+        }
+    }
+
+    @Test
+    fun `unknown status should classify as temporary only`() {
+        val result = ResendMailer.classifyResendStatus(recipient, statusCode = 418)
+        assertContains(result.temporary, recipient)
+        assertFalse(result.failed.contains(recipient))
+    }
+
+    @Test
+    fun `unexpected exception should classify as temporary only`() {
+        val result = ResendMailer.classifyUnexpectedException(recipient, RuntimeException("boom"))
+        assertContains(result.temporary, recipient)
+        assertFalse(
+            result.failed.contains(recipient),
+            "Unexpected errors must not also populate `failed`; got $result"
+        )
+    }
+}

--- a/src/test/kotlin/com/vandeas/service/impl/mailer/SMTPMailerClassificationTest.kt
+++ b/src/test/kotlin/com/vandeas/service/impl/mailer/SMTPMailerClassificationTest.kt
@@ -1,0 +1,75 @@
+package com.vandeas.service.impl.mailer
+
+import javax.mail.MessagingException
+import javax.mail.SendFailedException
+import javax.mail.internet.InternetAddress
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SMTPMailerClassificationTest {
+
+    private val recipient = "to@example.com"
+
+    @Test
+    fun `messaging exception should classify as temporary only, not also failed`() {
+        val result = SMTPMailer.classifyMessagingException(recipient, MessagingException("network glitch"))
+
+        assertContains(result.temporary, recipient)
+        assertFalse(
+            result.failed.contains(recipient),
+            "A temporary failure must not also be reported as a definitive `failed`; got $result"
+        )
+    }
+
+    // SendFailedException(msg, ex, validSent, validUnsent, invalid)
+    @Test
+    fun `permanent SMTP error should classify as bounced only, not also failed`() {
+        // Address rejected as invalid → hasInvalidAddresses → permanent
+        val sfe = SendFailedException(
+            "550 5.1.1 mailbox not found",
+            null,
+            null,
+            null,
+            arrayOf(InternetAddress(recipient))
+        )
+        val result = SMTPMailer.classifySendFailedException(recipient, sfe)
+
+        assertContains(result.bounced, recipient)
+        assertFalse(
+            result.failed.contains(recipient),
+            "A bounced (permanent) failure must not also be in `failed`; got $result"
+        )
+    }
+
+    @Test
+    fun `transient SMTP error should classify as temporary only`() {
+        // 421 = service not available — temporary; address landed in validUnsent
+        val sfe = SendFailedException(
+            "421 service not available",
+            null,
+            null,
+            arrayOf(InternetAddress(recipient)),
+            null
+        )
+        val result = SMTPMailer.classifySendFailedException(recipient, sfe)
+
+        assertContains(result.temporary, recipient)
+        assertFalse(
+            result.failed.contains(recipient),
+            "A temporary failure must not also be in `failed`; got $result"
+        )
+    }
+
+    @Test
+    fun `unexpected exception should classify as temporary only`() {
+        val result = SMTPMailer.classifyUnexpectedException(recipient, RuntimeException("boom"))
+
+        assertContains(result.temporary, recipient)
+        assertFalse(
+            result.failed.contains(recipient),
+            "Unexpected errors must not also be in `failed`; got $result"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Five independent correctness fixes in the queued-mail subsystem. Each fix lands in its own commit and ships with the test that proves it.

| # | Commit | What was wrong | What changed |
|---|---|---|---|
| 1 | `94964d9` | `processMailItem`'s outer `catch (e: Exception)` swallowed `CancellationException` and emitted a phantom failure result, breaking structured concurrency. | Re-throw `CancellationException` before catching `Exception`. |
| 2 | `a20a929` | The `when` block was non-exhaustive: a temporary failure that exceeded `maxRetries` matched no branch and was dropped silently — subscribers waiting on the reference would hang forever. | Added a terminal branch that promotes to a `failed` emission, plus an `else` for unrecognised empty results. |
| 3 | `a3aff10` | The retry backoff was advertised as exponential but computed linearly (`1000 * (retryCount + 1)` → 1s, 2s, 3s). | Switched to `1000 << retryCount` (1s, 2s, 4s, 8s, ...). |
| 4 | `24a8c33` | `getStats().queued` double-counted retries because the retry path called the public `enqueue`, which bumps the counter. | Split into a public `enqueue` (counts) and a private `submit` (does not), used by both the public path and the retry re-enqueue. |
| 5 | `217b8ea` | `SMTPMailer` and `ResendMailer` placed the recipient address in **both** `temporary`/`bounced` AND `failed` for every error path. Aggregations reported the same address twice and broke retry/status accounting. | Each error path now populates exactly one list. Extracted classification into testable companion functions and covered every branch. |

The convention going forward (enforced by tests):
- `bounced` → permanent, no retry, address only in `bounced`
- `temporary` → recoverable, address only in `temporary`
- `failed` → reserved for terminal failures decided by the queue after retries are exhausted

All fixes were developed test-first: each commit contains the test that fails on the prior commit and passes on its own.

## Test plan
- [x] `./gradlew test` green on full suite
- [x] Each fix's commit isolates one test that fails on its parent and passes after the fix
- [x] No public API changes outside of:
  - new `SMTPMailer` / `ResendMailer` companion classifiers (additive, used by tests)
  - `RateLimitedMailQueue` adds a private `submit` (no external surface change)

## Out of scope (flagged in code review, not in this PR)
- Reference tracking is still effectively dead code (`results` flow has no subscribers, `replay = 0` drops emissions).
- `Channel.UNLIMITED` has no backpressure.
- `AbstractQueuedMailer.shutdown()` not wired into the Ktor lifecycle; `MailLogicImpl.mailers` map never evicts.
- `sendEmailsWithRetry` ignores the caller's `maxRetries` / `retryDelayMs`.

These need API or lifecycle decisions and are tracked for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)