### PR TITLE
ci(docker): refactor release workflow — tests gate, GHA cache, metadata-action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,48 +1,114 @@
-name: Docker Image CI
+name: Release Docker image
 
 on:
   push:
+    # Only semver release tags. Pre-releases (-rc, -alpha, ...) are accepted by the
+    # trigger; the metadata action below decides whether they get the `:latest` tag.
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to (re-)publish, e.g. v2.0.0'
+        required: true
+        type: string
 
+permissions:
+  contents: read
 
 jobs:
-  docker:
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Get the version
-        id: get_version
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: '21'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Run tests
+        run: ./gradlew test --no-daemon
+
+  publish:
+    name: Build & publish image
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Resolve ref to checkout
+        id: resolve
         run: |
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "ref=refs/tags/${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
           else
-            echo ::set-output name=VERSION::latest
+            echo "ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.resolve.outputs.ref }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v5
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags & labels
+        id: meta
+        uses: docker/metadata-action@v5
         with:
+          images: |
+            lotuxpunk/hermes
+            ghcr.io/lotuxpunk/hermes
+          tags: |
+            # full semver, e.g. v1.2.3 -> 1.2.3
+            type=semver,pattern={{version}}
+            # major.minor, e.g. v1.2.3 -> 1.2
+            type=semver,pattern={{major}}.{{minor}}
+            # `latest` only on stable semver tags (no -rc / -alpha / -beta suffix)
+            type=raw,value=latest,enable=${{ !contains(steps.resolve.outputs.ref, '-') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            lotuxpunk/hermes:${{ steps.get_version.outputs.VERSION }}
-            lotuxpunk/hermes:latest
-            ghcr.io/lotuxpunk/hermes:${{ steps.get_version.outputs.VERSION }}
-            ghcr.io/lotuxpunk/hermes:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true


### PR DESCRIPTION
## Summary

Refactors `.github/workflows/docker-image.yml` to fix six classes of issues identified in the workflow review.

### What changes

| # | Fix | Before | After |
|---|---|---|---|
| 1 | Deprecated `::set-output` | Tags shipped with empty version after GitHub removed support in 2023. | `echo X >> $GITHUB_OUTPUT` (in the `resolve` step) and `docker/metadata-action@v5` for the actual tag derivation. |
| 2 | No tests before publish | `buildFatJar` skipped `test`. Bad commits could ship. | New `test` job runs `./gradlew test` on JDK 21; `publish` has `needs: test`. |
| 3 | `workflow_dispatch` clobbered `:latest` | Manual run on master pushed `lotuxpunk/hermes:latest` from current HEAD. | Manual run requires a `tag` input naming an existing semver tag and re-publishes from that tag. |
| 4 | `:latest` overwritten by pre-releases | A `v1.0.0-rc1` tag also retagged `:latest`, overriding stable. | `docker/metadata-action@v5` applies `:latest` only on stable semver (no `-` suffix). |
| 5 | Trigger pattern `'*'` too broad | Any tag fired the workflow. | `v[0-9]+.[0-9]+.[0-9]+` and `v[0-9]+.[0-9]+.[0-9]+-*` only. |
| 6 | No build cache | Every release rebuilt amd64 + arm64 from scratch under QEMU. | `cache-from: type=gha`, `cache-to: type=gha,mode=max`. Bumped `build-push-action` to v6 and turned on `provenance: true` + `sbom: true`. |

### Auth changes

- GHCR login now uses the built-in `secrets.GITHUB_TOKEN` (with job-level `packages: write`) instead of `secrets.GHCR_TOKEN`. **The `GHCR_TOKEN` repo secret can be deleted after this lands.**
- Top-level `permissions: contents: read` plus job-scoped overrides — no permission granted unless explicitly needed.

### Validation

- `actionlint` clean on all workflows in `.github/workflows/` (ran via `rhysd/actionlint` Docker image).
- The `test` job uses the same Gradle command and JDK version that pass locally on master.

## Test plan
- [ ] Merge → workflow shows up correctly in the Actions tab
- [ ] Push a throwaway test tag (e.g. `v0.0.0-test`) and confirm:
  - [ ] `test` runs and passes
  - [ ] `publish` builds with cache (first run will be cold)
  - [ ] Image lands on Docker Hub as `lotuxpunk/hermes:0.0.0-test` only — `:latest` is not overwritten because of the `-test` suffix
  - [ ] Image lands on GHCR with the same tag
  - [ ] Provenance and SBOM are attached (visible on Docker Hub UI)
- [ ] Run a `workflow_dispatch` with `tag = v0.0.0-test` and confirm it republishes the same artifact without changing `:latest`
- [ ] Delete the `GHCR_TOKEN` repo secret once the run is green

## Out of scope (follow-up PRs)

- Pinning action versions to commit SHAs (Dependabot territory).
- Cosign signing of the image digest.
- Native arm64 runners (currently arm64 builds via QEMU emulation).
- Smoke-test step that runs the published image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)